### PR TITLE
Move GeoIpProcessor static initializer

### DIFF
--- a/sawmill-core/src/main/java/io/logz/sawmill/processors/GeoIpProcessor.java
+++ b/sawmill-core/src/main/java/io/logz/sawmill/processors/GeoIpProcessor.java
@@ -40,10 +40,6 @@ import static java.util.Objects.requireNonNull;
 public class GeoIpProcessor implements Processor {
     private static DatabaseReader databaseReader;
 
-    static {
-        loadDatabaseReader();
-    }
-
     private static void loadDatabaseReader() {
         try (InputStream gzipInputStream = new GZIPInputStream(Resources.getResource("GeoLite2-City.tar.gz").openStream())) {
             try (TarArchiveInputStream tarArchiveInputStream = new TarArchiveInputStream(gzipInputStream)) {
@@ -135,6 +131,7 @@ public class GeoIpProcessor implements Processor {
         @Inject
         public Factory(TemplateService templateService) {
             this.templateService = templateService;
+            loadDatabaseReader();
         }
 
         @Override

--- a/sawmill-core/src/test/java/io/logz/sawmill/utils/FactoryUtils.java
+++ b/sawmill-core/src/test/java/io/logz/sawmill/utils/FactoryUtils.java
@@ -47,7 +47,7 @@ public class FactoryUtils {
         try {
             return (T) ProcessorFactoriesLoader.getInstance().getFactory(annotation);
         } catch (Exception e) {
-            throw new RuntimeException();
+            throw new RuntimeException(e);
         }
     }
 


### PR DESCRIPTION
Move init of GeoIpProcessor from static class initializer to Factory …constructor since when it fails, it goes all the way up to the Classloader which swallows the exception and just throws NoClassDefFound