### PR TITLE
disallow using Mustache Partials

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -143,7 +143,7 @@
             <dependency>
                 <groupId>com.github.spullara.mustache.java</groupId>
                 <artifactId>compiler</artifactId>
-                <version>0.9.2</version>
+                <version>0.9.10</version>
             </dependency>
   			<dependency>
                 <groupId>org.apache.commons</groupId>

--- a/sawmill-core/src/main/java/io/logz/sawmill/TemplateService.java
+++ b/sawmill-core/src/main/java/io/logz/sawmill/TemplateService.java
@@ -4,6 +4,8 @@ import com.github.mustachejava.Mustache;
 import com.github.mustachejava.MustacheFactory;
 import io.logz.sawmill.exceptions.SawmillException;
 
+import io.logz.sawmill.mustache.factories.UnescapedMustacheFactory;
+import io.logz.sawmill.mustache.factories.UnescapedWithJsonStringMustacheFactory;
 import java.io.StringReader;
 import java.io.StringWriter;
 import java.util.Arrays;

--- a/sawmill-core/src/main/java/io/logz/sawmill/mustache/factories/SafeMustacheCustomVisitorFactory.java
+++ b/sawmill-core/src/main/java/io/logz/sawmill/mustache/factories/SafeMustacheCustomVisitorFactory.java
@@ -5,12 +5,12 @@ import com.github.mustachejava.MustacheException;
 import com.github.mustachejava.MustacheVisitor;
 import com.github.mustachejava.SafeMustacheFactory;
 import com.github.mustachejava.TemplateContext;
-import java.util.Set;
+import java.util.Collections;
 
 public class SafeMustacheCustomVisitorFactory extends SafeMustacheFactory {
 
-    public SafeMustacheCustomVisitorFactory(Set<String> allowedResourceNames, String resourceRoot) {
-        super(allowedResourceNames, resourceRoot);
+    public SafeMustacheCustomVisitorFactory() {
+        super(Collections.emptySet(), "."); // disallow any resource reference
     }
 
     public MustacheVisitor createMustacheVisitor() {

--- a/sawmill-core/src/main/java/io/logz/sawmill/mustache/factories/SafeMustacheCustomVisitorFactory.java
+++ b/sawmill-core/src/main/java/io/logz/sawmill/mustache/factories/SafeMustacheCustomVisitorFactory.java
@@ -1,0 +1,23 @@
+package io.logz.sawmill.mustache.factories;
+
+import com.github.mustachejava.DefaultMustacheVisitor;
+import com.github.mustachejava.MustacheException;
+import com.github.mustachejava.MustacheVisitor;
+import com.github.mustachejava.SafeMustacheFactory;
+import com.github.mustachejava.TemplateContext;
+import java.util.Set;
+
+public class SafeMustacheCustomVisitorFactory extends SafeMustacheFactory {
+
+    public SafeMustacheCustomVisitorFactory(Set<String> allowedResourceNames, String resourceRoot) {
+        super(allowedResourceNames, resourceRoot);
+    }
+
+    public MustacheVisitor createMustacheVisitor() {
+        return new DefaultMustacheVisitor(this) {
+            public void pragma(TemplateContext tc, String pragma, String args) {
+                throw new MustacheException("Disallowed: pragmas in templates");
+            }
+        };
+    }
+}

--- a/sawmill-core/src/main/java/io/logz/sawmill/mustache/factories/SafeMustacheCustomVisitorFactory.java
+++ b/sawmill-core/src/main/java/io/logz/sawmill/mustache/factories/SafeMustacheCustomVisitorFactory.java
@@ -13,6 +13,7 @@ public class SafeMustacheCustomVisitorFactory extends SafeMustacheFactory {
         super(Collections.emptySet(), "."); // disallow any resource reference
     }
 
+    @Override
     public MustacheVisitor createMustacheVisitor() {
         return new DefaultMustacheVisitor(this) {
             public void pragma(TemplateContext tc, String pragma, String args) {

--- a/sawmill-core/src/main/java/io/logz/sawmill/mustache/factories/UnescapedMustacheFactory.java
+++ b/sawmill-core/src/main/java/io/logz/sawmill/mustache/factories/UnescapedMustacheFactory.java
@@ -1,10 +1,10 @@
-package io.logz.sawmill;
+package io.logz.sawmill.mustache.factories;
 
 import com.github.mustachejava.DefaultMustacheFactory;
 import com.github.mustachejava.MustacheException;
 import com.github.mustachejava.reflect.ReflectionObjectHandler;
-import io.logz.sawmill.utilities.JsonUtils;
 
+import com.google.common.collect.ImmutableSet;
 import java.io.IOException;
 import java.io.Writer;
 import java.util.List;
@@ -12,9 +12,9 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-public class UnescapedWithJsonStringMustacheFactory extends DefaultMustacheFactory {
-    public UnescapedWithJsonStringMustacheFactory() {
-        super();
+public class UnescapedMustacheFactory extends SafeMustacheCustomVisitorFactory {
+    public UnescapedMustacheFactory() {
+        super(ImmutableSet.of(), ".");
 
         this.setObjectHandler(new ListTransformObjectHandler());
     }
@@ -29,15 +29,6 @@ public class UnescapedWithJsonStringMustacheFactory extends DefaultMustacheFacto
     }
 
     public class ListTransformObjectHandler extends ReflectionObjectHandler {
-        @Override
-        public String stringify(Object object) {
-            if (object instanceof Map) {
-                return JsonUtils.toJsonString(object);
-            }
-
-            return super.stringify(object);
-        }
-
         @Override
         public Object coerce(final Object object) {
             if (object != null && object instanceof List) {

--- a/sawmill-core/src/main/java/io/logz/sawmill/mustache/factories/UnescapedMustacheFactory.java
+++ b/sawmill-core/src/main/java/io/logz/sawmill/mustache/factories/UnescapedMustacheFactory.java
@@ -1,10 +1,7 @@
 package io.logz.sawmill.mustache.factories;
 
-import com.github.mustachejava.DefaultMustacheFactory;
 import com.github.mustachejava.MustacheException;
 import com.github.mustachejava.reflect.ReflectionObjectHandler;
-
-import com.google.common.collect.ImmutableSet;
 import java.io.IOException;
 import java.io.Writer;
 import java.util.List;
@@ -14,8 +11,6 @@ import java.util.stream.IntStream;
 
 public class UnescapedMustacheFactory extends SafeMustacheCustomVisitorFactory {
     public UnescapedMustacheFactory() {
-        super(ImmutableSet.of(), ".");  // disallow any resource reference
-
         this.setObjectHandler(new ListTransformObjectHandler());
     }
 

--- a/sawmill-core/src/main/java/io/logz/sawmill/mustache/factories/UnescapedMustacheFactory.java
+++ b/sawmill-core/src/main/java/io/logz/sawmill/mustache/factories/UnescapedMustacheFactory.java
@@ -14,7 +14,7 @@ import java.util.stream.IntStream;
 
 public class UnescapedMustacheFactory extends SafeMustacheCustomVisitorFactory {
     public UnescapedMustacheFactory() {
-        super(ImmutableSet.of(), ".");
+        super(ImmutableSet.of(), ".");  // disallow any resource reference
 
         this.setObjectHandler(new ListTransformObjectHandler());
     }

--- a/sawmill-core/src/main/java/io/logz/sawmill/mustache/factories/UnescapedWithJsonStringMustacheFactory.java
+++ b/sawmill-core/src/main/java/io/logz/sawmill/mustache/factories/UnescapedWithJsonStringMustacheFactory.java
@@ -1,9 +1,9 @@
-package io.logz.sawmill;
+package io.logz.sawmill.mustache.factories;
 
-import com.github.mustachejava.DefaultMustacheFactory;
 import com.github.mustachejava.MustacheException;
 import com.github.mustachejava.reflect.ReflectionObjectHandler;
-
+import com.google.common.collect.ImmutableSet;
+import io.logz.sawmill.utilities.JsonUtils;
 import java.io.IOException;
 import java.io.Writer;
 import java.util.List;
@@ -11,9 +11,9 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-public class UnescapedMustacheFactory extends DefaultMustacheFactory {
-    public UnescapedMustacheFactory() {
-        super();
+public class UnescapedWithJsonStringMustacheFactory extends SafeMustacheCustomVisitorFactory {
+    public UnescapedWithJsonStringMustacheFactory() {
+        super(ImmutableSet.of(), ".");
 
         this.setObjectHandler(new ListTransformObjectHandler());
     }
@@ -28,6 +28,15 @@ public class UnescapedMustacheFactory extends DefaultMustacheFactory {
     }
 
     public class ListTransformObjectHandler extends ReflectionObjectHandler {
+        @Override
+        public String stringify(Object object) {
+            if (object instanceof Map) {
+                return JsonUtils.toJsonString(object);
+            }
+
+            return super.stringify(object);
+        }
+
         @Override
         public Object coerce(final Object object) {
             if (object != null && object instanceof List) {

--- a/sawmill-core/src/main/java/io/logz/sawmill/mustache/factories/UnescapedWithJsonStringMustacheFactory.java
+++ b/sawmill-core/src/main/java/io/logz/sawmill/mustache/factories/UnescapedWithJsonStringMustacheFactory.java
@@ -13,7 +13,7 @@ import java.util.stream.IntStream;
 
 public class UnescapedWithJsonStringMustacheFactory extends SafeMustacheCustomVisitorFactory {
     public UnescapedWithJsonStringMustacheFactory() {
-        super(ImmutableSet.of(), ".");
+        super(ImmutableSet.of(), ".");  // disallow any resource reference
 
         this.setObjectHandler(new ListTransformObjectHandler());
     }

--- a/sawmill-core/src/main/java/io/logz/sawmill/mustache/factories/UnescapedWithJsonStringMustacheFactory.java
+++ b/sawmill-core/src/main/java/io/logz/sawmill/mustache/factories/UnescapedWithJsonStringMustacheFactory.java
@@ -2,7 +2,6 @@ package io.logz.sawmill.mustache.factories;
 
 import com.github.mustachejava.MustacheException;
 import com.github.mustachejava.reflect.ReflectionObjectHandler;
-import com.google.common.collect.ImmutableSet;
 import io.logz.sawmill.utilities.JsonUtils;
 import java.io.IOException;
 import java.io.Writer;
@@ -13,8 +12,6 @@ import java.util.stream.IntStream;
 
 public class UnescapedWithJsonStringMustacheFactory extends SafeMustacheCustomVisitorFactory {
     public UnescapedWithJsonStringMustacheFactory() {
-        super(ImmutableSet.of(), ".");  // disallow any resource reference
-
         this.setObjectHandler(new ListTransformObjectHandler());
     }
 

--- a/sawmill-core/src/test/java/io/logz/sawmill/TemplateTest.java
+++ b/sawmill-core/src/test/java/io/logz/sawmill/TemplateTest.java
@@ -88,6 +88,13 @@ public class TemplateTest {
     }
 
     @Test
+    public void testInvalidAccessWithMustachePartials() {
+        assertThatThrownBy(() -> new TemplateService().createTemplate("This is my host file content:\n {{>/etc/hosts}}"))
+                .isInstanceOf(MustacheException.class)
+                .hasMessageContaining("Disallowed: resource requested");
+    }
+
+    @Test
     public void testDateTemplate() {
         String dateFormat = "dd.MM.yyyy";
         Template template = new TemplateService().createTemplate("Today is {{#dateTemplate}}" + dateFormat + "{{/dateTemplate}}");
@@ -103,8 +110,8 @@ public class TemplateTest {
         Template template = new TemplateService().createTemplate("Today is {{#dateTemplate}}" + dateFormat + "{{/dateTemplate}}");
         Doc doc = createDoc("field1", "value1");
 
-        assertThatThrownBy(() -> template.render(doc)).isInstanceOf(MustacheException.class);
-        assertThatThrownBy(() -> template.render(doc)).hasCauseExactlyInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> template.render(doc)).isInstanceOf(MustacheException.class)
+                                                      .hasCauseExactlyInstanceOf(IllegalArgumentException.class);
     }
 
     @Test

--- a/sawmill-core/src/test/java/io/logz/sawmill/TemplateTest.java
+++ b/sawmill-core/src/test/java/io/logz/sawmill/TemplateTest.java
@@ -1,5 +1,6 @@
 package io.logz.sawmill;
 
+import com.github.mustachejava.MustacheException;
 import com.google.common.collect.ImmutableMap;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -102,7 +103,8 @@ public class TemplateTest {
         Template template = new TemplateService().createTemplate("Today is {{#dateTemplate}}" + dateFormat + "{{/dateTemplate}}");
         Doc doc = createDoc("field1", "value1");
 
-        assertThatThrownBy(() -> template.render(doc)).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> template.render(doc)).isInstanceOf(MustacheException.class);
+        assertThatThrownBy(() -> template.render(doc)).hasCauseExactlyInstanceOf(IllegalArgumentException.class);
     }
 
     @Test


### PR DESCRIPTION
As part of this PR, we upgraded also the mustache version to 0.9.10.
We could have different approach and even not upgrade the mustache version and do it a bit differently (by using `FileSystemResolver` and customize that the `working_directory`), but decided to be more aligned with our current approach and also to disallow any file reference in this case even if it's located inside our `working_directory`.
