### PR TITLE
Upgraded jackson databind version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -173,7 +173,7 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
-                <version>2.9.10.1</version>
+                <version>2.9.10.4</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>


### PR DESCRIPTION
Upgraded jackson version to handle [CVE-2020-9548](https://github.com/advisories/GHSA-p43x-xfjf-5jhr)